### PR TITLE
fix: fix bug in examples/standard.yaml for imagePullPolicy

### DIFF
--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -7,7 +7,7 @@ metadata:
     kvrocks/system: gt
 spec:
   image: apache/kvrocks:2.3.0
-  imagePullPolicy: Always
+  imagePullPolicy: IfNotPresent
   master: 1
   replicas: 3
   type: standard


### PR DESCRIPTION
Hi,
Since we need to rebuild the kvrocks image (in README), the imagePullPolicy cannot be Always.