### PR TITLE
refactor: remove bin dict and improve go-get-tool in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 testbin/*
+bin
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -167,12 +167,8 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2); \
 }
 endef
 


### PR DESCRIPTION
Hi，
This PR is for improving the developer experience.

The bin directory is removed from the repository since we can download binary files such as "controller-gen" locally using "make controller-gen" command.
