### PR TITLE
build: improve the user experience of docker-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ testbin/*
 
 !vendor/**/zz_generated.*
 
+vendor/
 # editor and IDE paraphernalia
 .idea
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG USE_VENDOR=false
+ARG USE_VENDOR=Disabled
 
 # Build the manager binary
 FROM golang:1.17 as builder
@@ -17,12 +17,12 @@ COPY pkg/ pkg/
 COPY vendor* vendor/
 
 
-FROM builder as vendor-true
+FROM builder as vendor-Enabled
 ARG TARGETARCH
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager main.go
 
-FROM builder as vendor-false
+FROM builder as vendor-Disabled
 ARG TARGETARCH
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG USE_VENDOR=false
+
 # Build the manager binary
 FROM golang:1.17 as builder
 
@@ -12,15 +14,26 @@ COPY go.sum go.sum
 COPY main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
+COPY vendor* vendor/
 
+
+FROM builder as vendor-true
+ARG TARGETARCH
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOPROXY=https://goproxy.cn go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager main.go
+
+FROM builder as vendor-false
+ARG TARGETARCH
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
+
+FROM vendor-${USE_VENDOR} as vendor
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=vendor /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,10 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif
 
+REGISTRY ?= kvrocks.com/kvrockslabs
+TAG ?= latest
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= $(REGISTRY)/kvrocks-operator:$(TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -98,18 +100,27 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
+.PHONY: vendor
+vendor:
+	go mod vendor
+
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	@echo "Reminder: Please continue to add test cases!"
+##	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+
+.PHONY: buildx
+buildx: 
+	docker buildx install
 
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate fmt vet vendor ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
@@ -117,8 +128,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+docker-build: test buildx ## Build docker image with the manager.
+	docker buildx build --build-arg USE_VENDOR=false -t ${IMG} . --load
+
+.PHONY: docker-build-vendor
+docker-build-vendor: test buildx vendor
+	docker buildx build --build-arg USE_VENDOR=true -t ${IMG} . --load
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test buildx ## Build docker image with the manager.
-	docker buildx build --build-arg USE_VENDOR=false -t ${IMG} . --load
+	docker buildx build --build-arg USE_VENDOR=Disabled -t ${IMG} . --load
 
 .PHONY: docker-build-vendor
 docker-build-vendor: test buildx vendor
-	docker buildx build --build-arg USE_VENDOR=true -t ${IMG} . --load
+	docker buildx build --build-arg USE_VENDOR=Enabled -t ${IMG} . --load
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the kvrocks.com v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=kvrocks.com
+// +kubebuilder:object:generate=true
+// +groupName=kvrocks.com
 package v1alpha1
 
 import (

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the kvrocks.com v1alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=kvrocks.com
+//+kubebuilder:object:generate=true
+//+groupName=kvrocks.com
 package v1alpha1
 
 import (


### PR DESCRIPTION
Hi,
This PR is for improving the user experience of docker-build. And the related issue is #6 

I intorduce the `REGISTRY` and `TAG` in Makefile. And introduce the `USE_VENDOR` in Dockerfile. I also remove the hard code in Dockerfile about the platform.

Thus, the developer can build image by following commands

```bash
# build image with tag "kvrocks.com/kvrockslabs/kvrocks-operator:latest"
make docker-build

# build image with tag "kvrockslabs/kvrocks-operator:latest"
REGISTRY=kvrockslabs make docker-build

# build image with tag "kvrocks.com/kvrockslabs/kvrocks-operator:nightly"
TAG=nightly make docker-build
```

To build faster (using vendor) by following commands

```bash
make docker-build-vendor
```

**Note! the above introduction will be added in the development guide #5**

**Reminder: There are currently missing essential test cases in the code, and I'm working hard to complete them.**
