### PR TITLE
Remove the description in the README about rebuilding the image

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,9 +25,11 @@ helm install kruise openkruise/kruise --version 1.4.0
 kubectl create ns kvrocks
 ```
 
-3. helm install kvrocks-crd deploy/crd -n kvrocks
-
-4. helm install kvrocks-operator deploy/operator -n kvrocks
+3. Use helm to install and manage the crd/operator 
+```
+helm install kvrocks-crd deploy/crd -n kvrocks
+helm install kvrocks-operator deploy/operator -n kvrocks
+```
 
 ### Test
 

--- a/Readme.md
+++ b/Readme.md
@@ -3,30 +3,30 @@
 
 ## Getting Start
 
-```text
-Please rebuild the kvrocks image, you need to install the redis-cli command tool.
-```
-
-```dockerfile
-FROM kvrocks:2.3.0
-RUN apt update && apt install -y redis-server
-```
-
-```text
-Note the naming rules of kvrocks
-kvrocks-cluster-1-demo
-consists of four parts
-1. kvrocks logo
-2. cluster|standard|sentinel
-3. Indicate the sentinel cluster to be used. In this case, the sentinel cluster is: sentinel-1
-4. kvrocks cluster name
-```
+> Note the naming rules of kvrocks
+> kvrocks-cluster-1-demo
+> consists of four parts
+> 1. kvrocks logo
+> 2. cluster|standard|sentinel
+> 3. Indicate the sentinel cluster to be used. In this case, the sentinel cluster is: sentinel-1
+> 4. kvrocks cluster name
 
 ### Deploy
 
 1. Install OpenKruise
+
+```
+helm repo add openkruise https://openkruise.github.io/charts/
+helm repo update
+helm install kruise openkruise/kruise --version 1.4.0
+```
 2. Create ns kvrocks
+```
+kubectl create ns kvrocks
+```
+
 3. helm install kvrocks-crd deploy/crd -n kvrocks
+
 4. helm install kvrocks-operator deploy/operator -n kvrocks
 
 ### Test

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -6,7 +6,7 @@ managerNamespace:
 imagePullPolicy: Always
 imagePullSecrets:
 
-kubeRBACProxyImage: bitnami/kube-rbac-proxy:v0.14.0
+kubeRBACProxyImage: bitnami/kube-rbac-proxy:0.14.0
 
 resources:
   requests:

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kvrocks/system: xx
 spec:
-  image: apache/kvrocks:2.3.0 # kvrocks image
+  image: apache/kvrocks:nightly # kvrocks image
   imagePullPolicy: IfNotPresent
   master: 3
   replicas: 3

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kvrocks/system: gt
 spec:
-  image: apache/kvrocks:2.3.0
+  image: apache/kvrocks:nightly
   imagePullPolicy: IfNotPresent
   master: 1
   replicas: 3


### PR DESCRIPTION
fix #15 
test step：

1、deploy a standard
change image from apache/kvrocks:2.3.0 to apache/kvrocks:nightly
```
kubectl apply -f examples/standard.yaml
```
2、exec redis-cli in pod
```
➜  kvrocks-operator git:(unstable) ✗ kubectl exec -it kvrocks-standard-1-demo-0 -n kvrocks -- /bin/bash
root@kvrocks-standard-1-demo-0:/kvrocks# redis-cli
127.0.0.1:6379> 
```

other error fix:
image `bitnami/kube-rbac-proxy:0.14.0` not have tag v0.14.0
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/87080562/236762600-3044c5cb-c8c3-42f4-a41f-e327622b1112.png">
