### PR TITLE
fix: remove the `USE_VENDOR`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG USE_VENDOR=disabled
-
 # Build the manager binary
 FROM golang:1.19 as builder
 
@@ -14,26 +12,18 @@ COPY go.sum go.sum
 COPY main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
-COPY vendor* vendor/
 
 
-FROM builder as vendor-enabled
 ARG TARGETARCH
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=mod -a -o manager main.go
 
-FROM builder as vendor-disabled
-ARG TARGETARCH
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
-
-FROM vendor-${USE_VENDOR} as vendor
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=vendor /workspace/manager .
+COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
 endif
 
-REGISTRY ?= kvrocks.com/kvrockslabs
+REGISTRY ?= apache.org/rockslabs
 TAG ?= latest
 # Image URL to use all building/pushing image targets
 IMG ?= $(REGISTRY)/kvrocks-operator:$(TAG)
@@ -129,11 +129,8 @@ run: manifests generate fmt vet install ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test buildx ## Build docker image with the manager.
-	docker buildx build --build-arg USE_VENDOR=disabled -t ${IMG} . --load
+	docker buildx build -t ${IMG} . --load
 
-.PHONY: docker-build-vendor
-docker-build-vendor: test buildx vendor
-	docker buildx build --build-arg USE_VENDOR=enabled -t ${IMG} . --load
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,20 +90,13 @@ The binary would be generated in the `bin` directory
 To build a Docker/OCI-compatible image of the Kvrocks operator, run the following command:
 
 ```bash
-# build image with tag "kvrocks.com/kvrockslabs/kvrocks-operator:latest"
+# build image with tag "apache.org/rockslabs/kvrocks-operator:latest"
 make docker-build
 
-# build image with tag "kvrockslabs/kvrocks-operator:latest"
-REGISTRY=kvrockslabs make docker-build
+# build image with tag "rockslabs/kvrocks-operator:latest"
+REGISTRY=rockslabs make docker-build
 
-# build image with tag "kvrocks.com/kvrockslabs/kvrocks-operator:nightly"
+# build image with tag "apache.org/rockslabs/kvrocks-operator:nightly"
 TAG=nightly make docker-build
 ```
-
-To build image with `vendor` run the following command:
-
-```bash
-make docker-build-vendor
-```
-
 

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -61,7 +61,7 @@ var _ = BeforeSuite(func() {
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 	})
-        Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	KVRocksClient = kvrocks.NewKVRocksClient(ctrl.Log)
 


### PR DESCRIPTION
Hi,
Since Dockerfile does not support conditional judgement, it is a good choice to only build the image in mod mode. Otherwise, it will build twice due to the introduction of `USE_VENDOR`.