### PR TITLE
fix: use the default storageclass when the storageclass is nil

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,9 +39,9 @@ helm install kvrocks-operator deploy/operator -n kvrocks
    - kubectl apply -f examples/cluster.yaml
 
 ```text
-If the storageclass is nil, we will use the (default) storageclass in the current cluster, or the size is nil, the default size will be set 200Mi (just for test):
+If a storage class is not specified, we will use the default storage class. For instance, in Amazon EKS, the default storage class is gp2.
   storage:
-    size: 32Gi
+    size: 10Gi  # If size is not specified, its default value is 10Gi.
     class: xxxxx # storage class
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ helm install kvrocks-operator deploy/operator -n kvrocks
    - kubectl apply -f examples/cluster.yaml
 
 ```text
-If the storage class is nil, we will use the (default) storageclass in the current cluster, or the size is nil, the default size will be set 200Mi (just for test):
+If the storageclass is nil, we will use the (default) storageclass in the current cluster, or the size is nil, the default size will be set 200Mi (just for test):
   storage:
     size: 32Gi
     class: xxxxx # storage class

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ helm install kvrocks-operator deploy/operator -n kvrocks
    - kubectl apply -f examples/cluster.yaml
 
 ```text
-The default data is not persistent, if you want to persist the data, please modify the following fields of the case:
+If the storage class is nil, we will use the (default) storageclass in the current cluster, or the size is nil, the default size will be set 200Mi (just for test):
   storage:
     size: 32Gi
     class: xxxxx # storage class

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -11,10 +11,10 @@ kubeRBACProxyImage: bitnami/kube-rbac-proxy:0.14.0
 resources:
   requests:
     memory: "1Gi"
-    cpu: "1000m"
+    cpu: "500m"
   limits:
-    memory: "4Gi"
-    cpu: "4000m"
+    memory: "2Gi"
+    cpu: "1000m"
 
 # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 maxConcurrentReconciles: 1024

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -11,10 +11,10 @@ kubeRBACProxyImage: bitnami/kube-rbac-proxy:0.14.0
 resources:
   requests:
     memory: "1Gi"
-    cpu: "500m"
-  limits:
-    memory: "2Gi"
     cpu: "1000m"
+  limits:
+    memory: "4Gi"
+    cpu: "4000m"
 
 # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 maxConcurrentReconciles: 1024

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -9,7 +9,7 @@ spec:
   image: apache/kvrocks:nightly
   imagePullPolicy: IfNotPresent
   master: 1
-  replicas: 1
+  replicas: 3
   type: standard
   enableSentinel: true
   password: "123456"

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -9,7 +9,7 @@ spec:
   image: apache/kvrocks:nightly
   imagePullPolicy: IfNotPresent
   master: 1
-  replicas: 3
+  replicas: 1
   type: standard
   enableSentinel: true
   password: "123456"
@@ -42,9 +42,7 @@ spec:
     rocksdb.wal_size_limit_mb: "0"
 #  storage:
 #    size: 32Gi
-#    class: local-hostpath # storage class
-#  nodeSelector:
-#    role: kvrocks
+#    class: local-hostpath
   toleration:
     - key: kvrocks
       effect: NoSchedule

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -9,7 +9,7 @@ spec:
   image: apache/kvrocks:nightly
   imagePullPolicy: IfNotPresent
   master: 1
-  replicas: 3
+  replicas: 1
   type: standard
   enableSentinel: true
   password: "123456"

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -16,6 +16,7 @@ import (
 )
 
 var TerminationGracePeriodSeconds int64 = 20
+const DefaultStorageSize = "10Gi"
 
 func NewStatefulSet(instance *kvrocksv1alpha1.KVRocks, name string) *kruise.StatefulSet {
 	labels := MergeLabels(instance.Labels, StatefulSetLabels(name))
@@ -106,7 +107,7 @@ func getAffinity(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) *c
 func getPersistentClaim(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) corev1.PersistentVolumeClaim {
 	mode := corev1.PersistentVolumeFilesystem
 	var class *string = nil
-	size := resource.MustParse("200Mi")
+	size := resource.MustParse(DefaultStorageSize)
 	if instance.Spec.Storage != nil {
 		if instance.Spec.Storage.Class != "" {
 			class = &instance.Spec.Storage.Class

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -106,7 +106,7 @@ func getAffinity(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) *c
 func getPersistentClaim(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) corev1.PersistentVolumeClaim {
 	mode := corev1.PersistentVolumeFilesystem
 	var class *string = nil
-	size := resource.MustParse("1Gi")
+	size := resource.MustParse("200Mi")
 	if instance.Spec.Storage != nil {
 		if instance.Spec.Storage.Class != "" {
 			class = &instance.Spec.Storage.Class

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -9,6 +9,7 @@ import (
 	kruise "github.com/openkruise/kruise-api/apps/v1beta1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kvrocksv1alpha1 "github.com/RocksLabs/kvrocks-operator/api/v1alpha1"
@@ -74,11 +75,8 @@ func NewStatefulSet(instance *kvrocksv1alpha1.KVRocks, name string) *kruise.Stat
 			},
 		},
 	}
-	if instance.Spec.Storage != nil {
-		sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, getPersistentClaim(instance, labels))
-	} else {
-		sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, getRedisDataVolume(instance))
-	}
+
+	sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, getPersistentClaim(instance, labels))
 	return sts
 }
 
@@ -108,8 +106,15 @@ func getAffinity(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) *c
 func getPersistentClaim(instance *kvrocksv1alpha1.KVRocks, labels map[string]string) corev1.PersistentVolumeClaim {
 	mode := corev1.PersistentVolumeFilesystem
 	var class *string = nil
-	if instance.Spec.Storage.Class != "" {
-		class = &instance.Spec.Storage.Class
+	size := resource.MustParse("1Gi")
+	if instance.Spec.Storage != nil {
+		if instance.Spec.Storage.Class != "" {
+			class = &instance.Spec.Storage.Class
+		}
+
+		if !instance.Spec.Storage.Size.IsZero() {
+			size = instance.Spec.Storage.Size
+		}
 	}
 	return corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -123,20 +128,11 @@ func getPersistentClaim(instance *kvrocksv1alpha1.KVRocks, labels map[string]str
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: instance.Spec.Storage.Size,
+					corev1.ResourceStorage: size,
 				},
 			},
 			StorageClassName: class,
 			VolumeMode:       &mode,
-		},
-	}
-}
-
-func getRedisDataVolume(instance *kvrocksv1alpha1.KVRocks) corev1.Volume {
-	return corev1.Volume{
-		Name: "data",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
 }


### PR DESCRIPTION
Hi,
This pr is for pvc.
In the current version, we use emptyDir when the storageClass is nil. However, this is not suitable for kvrocks. Therefore, we can substitute emptyDir with the default storageClass.

**Note:** if you use the minikube as your local kubernetes cluster (+2 nodes), you should refer this [issue](https://github.com/kubernetes/minikube/issues/12360) for more detail. 