### PR TITLE
feat: ensure the mount path is the same as kvrocks' dockerfile

### DIFF
--- a/config/crd/bases/kvrocks.apache.org_kvrocks.yaml
+++ b/config/crd/bases/kvrocks.apache.org_kvrocks.yaml
@@ -891,26 +891,6 @@ spec:
               resources:
                 description: ResourceRequirements describes the compute resource requirements.
                 properties:
-                  claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable."
-                    items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                      properties:
-                        name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
                   limits:
                     additionalProperties:
                       anyOf:

--- a/examples/standard.yaml
+++ b/examples/standard.yaml
@@ -40,9 +40,9 @@ spec:
     rocksdb.compression: "no"
     rocksdb.wal_ttl_seconds: "0"
     rocksdb.wal_size_limit_mb: "0"
-#  storage:
-#    size: 32Gi
-#    class: local-hostpath
+  # storage:
+  #   size: 32Gi
+  #   class: local-hostpath
   toleration:
     - key: kvrocks
       effect: NoSchedule

--- a/main.go
+++ b/main.go
@@ -28,13 +28,13 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	kruise "github.com/openkruise/kruise-api"
+	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	uberzap "go.uber.org/zap"
 
 	kvrocksv1alpha1 "github.com/RocksLabs/kvrocks-operator/api/v1alpha1"
 	"github.com/RocksLabs/kvrocks-operator/pkg/controllers"

--- a/pkg/controllers/standard/kvrocks.go
+++ b/pkg/controllers/standard/kvrocks.go
@@ -133,6 +133,7 @@ func (h *KVRocksStandardHandler) updateSentinelAnnotationCount(sentinelName stri
 	if err := h.k8s.UpdateKVRocks(sentinel); err != nil {
 		return err
 	}
+	h.log.V(1).Info("sentinel monitor ready")
 	return nil
 }
 

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -50,12 +50,12 @@ const (
 	start = `
 #!/bin/bash
 sleep 15
-./bin/kvrocks -c /conf/kvrocks.conf
+./bin/kvrocks -c /var/lib/kvrocks/conf/kvrocks.conf
 `
 
 	readinessProbe = `
 #!/bin/sh
-timeout 30 redis-cli -a $(cat /conf/password) --no-auth-warning ping || timeout 30 redis-cli --no-auth-warning ping
+timeout 30 redis-cli -a $(cat /var/lib/kvrocks/conf/password) --no-auth-warning ping || timeout 30 redis-cli --no-auth-warning ping
 `
 )
 
@@ -92,7 +92,7 @@ func NewKVRocksConfigMap(instance *kvrocksv1alpha1.KVRocks) *corev1.ConfigMap {
 	// set auth config
 	buffer.WriteString(fmt.Sprintf("masterauth %s\n", instance.Spec.Password))
 	buffer.WriteString(fmt.Sprintf("requirepass %s\n", instance.Spec.Password))
-	buffer.WriteString("dir /data\n")
+	buffer.WriteString("dir /var/lib/kvrocks\n")
 	if instance.Spec.Type == kvrocksv1alpha1.ClusterType {
 		buffer.WriteString("cluster-enabled yes\n")
 	}

--- a/test/e2e/util/config.go
+++ b/test/e2e/util/config.go
@@ -19,12 +19,12 @@ const (
 )
 
 type Config struct {
-	KruiseVersion string `yaml:"kruiseVersion"`
-	ClusterName   string `yaml:"clusterName"`
-	Namespace     string `yaml:"namespace"`
-	KubeConfig    string `yaml:"kubeConfig"`
+	KruiseVersion    string `yaml:"kruiseVersion"`
+	ClusterName      string `yaml:"clusterName"`
+	Namespace        string `yaml:"namespace"`
+	KubeConfig       string `yaml:"kubeConfig"`
 	ChaosMeshEnabled bool   `yaml:"chaosMeshEnabled"`
-	ManifestDir   string `yaml:"manifestDir"`
+	ManifestDir      string `yaml:"manifestDir"`
 }
 
 func NewConfig(configFilePath string) (*Config, error) {

--- a/test/e2e/util/kubernetes_env.go
+++ b/test/e2e/util/kubernetes_env.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"time"
-	"reflect"
 
 	kvrocksv1alpha1 "github.com/RocksLabs/kvrocks-operator/api/v1alpha1"
 	chaosmeshv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"


### PR DESCRIPTION
Hi.
Since the dockerfile in the kvrocks repo has the [volume path `/var/lib/kvrocks'](https://github.com/apache/kvrocks/blob/f96c5359c3a522da048f5717c097b39049320252/Dockerfile#L33C1-L34C1), we need to make sure the path in k8s is the same as the dockerfile.