### PR TITLE
fix: can't write data by connecting kvrocks-svc

### DIFF
--- a/pkg/controllers/cluster/kvrocks.go
+++ b/pkg/controllers/cluster/kvrocks.go
@@ -203,8 +203,8 @@ func (h *KVRocksClusterHandler) updatePodLabels(key types.NamespacedName, role s
 	if err != nil {
 		return err
 	}
-	if pod.Labels[resources.RedisRole] != role {
-		pod.Labels[resources.RedisRole] = role
+	if pod.Labels[resources.KvrocksRole] != role {
+		pod.Labels[resources.KvrocksRole] = role
 		if err = h.k8s.UpdatePod(pod); err != nil {
 			return err
 		}

--- a/pkg/controllers/standard/kvrocks.go
+++ b/pkg/controllers/standard/kvrocks.go
@@ -146,8 +146,8 @@ func (h *KVRocksStandardHandler) updateKVRocksRole(podID int, role string) error
 	if err != nil {
 		return err
 	}
-	if pod.Labels[resources.RedisRole] != role {
-		pod.Labels[resources.RedisRole] = role
+	if pod.Labels[resources.KvrocksRole] != role {
+		pod.Labels[resources.KvrocksRole] = role
 		return h.k8s.UpdatePod(pod)
 	}
 	return nil

--- a/pkg/resources/labels.go
+++ b/pkg/resources/labels.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	MonitoredBy = "kvrocks/monitored-by"
-	RedisRole   = "kvrocks/role"
+	KvrocksRole = "kvrocks/role"
 )
 
 func MergeLabels(allLabels ...map[string]string) map[string]string {

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -47,7 +47,9 @@ func NewKVRocksService(instance *kvrocksv1alpha1.KVRocks) *corev1.Service {
 					Port: kvrocks.KVRocksPort,
 				},
 			},
-			Selector: instance.Labels,
+			Selector: MergeLabels(instance.Labels, map[string]string{
+				KvrocksRole: kvrocks.RoleMaster,
+			}),
 		},
 	}
 }

--- a/test/e2e/standard/standard_test.go
+++ b/test/e2e/standard/standard_test.go
@@ -152,8 +152,8 @@ var _ = Describe("Operator for Standard Mode", func() {
 			if pod.Status.Phase != corev1.PodRunning {
 				return errors.New("please wait pod running")
 			}
-			if pod.Labels[resources.RedisRole] != kvrocks.RoleSlaver {
-				return fmt.Errorf("role is incorrect, expect: %s, actual: %s", kvrocks.RoleSlaver, pod.Labels[resources.RedisRole])
+			if pod.Labels[resources.KvrocksRole] != kvrocks.RoleSlaver {
+				return fmt.Errorf("role is incorrect, expect: %s, actual: %s", kvrocks.RoleSlaver, pod.Labels[resources.KvrocksRole])
 			}
 			return nil
 		}, timeout, interval).Should(Succeed())
@@ -174,8 +174,8 @@ var _ = Describe("Operator for Standard Mode", func() {
 			if pod.Status.Phase != corev1.PodRunning {
 				return errors.New("please wait pod running")
 			}
-			if pod.Labels[resources.RedisRole] != kvrocks.RoleSlaver {
-				return fmt.Errorf("role is incorrect, expect: %s, actual: %s", kvrocks.RoleSlaver, pod.Labels[resources.RedisRole])
+			if pod.Labels[resources.KvrocksRole] != kvrocks.RoleSlaver {
+				return fmt.Errorf("role is incorrect, expect: %s, actual: %s", kvrocks.RoleSlaver, pod.Labels[resources.KvrocksRole])
 			}
 			return nil
 		}, timeout, interval).Should(Succeed())
@@ -275,8 +275,8 @@ func checkKVRocks(kvrocksInstance, sentinelInstance *kvrocksv1alpha1.KVRocks) er
 		if err != nil {
 			return err
 		}
-		if node.Role != pod.Labels[resources.RedisRole] {
-			return fmt.Errorf("reole label is incorrect,expect: %s, actual: %s", node.Role, pod.Labels[resources.RedisRole])
+		if node.Role != pod.Labels[resources.KvrocksRole] {
+			return fmt.Errorf("reole label is incorrect,expect: %s, actual: %s", node.Role, pod.Labels[resources.KvrocksRole])
 		}
 		if node.Role == kvrocks.RoleMaster {
 			masterIP = append(masterIP, node.IP)
@@ -363,7 +363,7 @@ func getKvrocksByRole(instance *kvrocksv1alpha1.KVRocks, role string) (key types
 			Name:      fmt.Sprintf("%s-%d", instance.GetName(), i),
 		}
 		Expect(env.Client.Get(ctx, key, &pod)).Should(Succeed())
-		if pod.Labels[resources.RedisRole] == role {
+		if pod.Labels[resources.KvrocksRole] == role {
 			break
 		}
 	}


### PR DESCRIPTION
The kvrocks instance can exist as a standalone service. Since there is kvrocks-svc, let's point it to the master.