### PR TITLE
 Fix error handling for existing entries in CreateIfNotExistsNamespace

### DIFF
--- a/pkg/client/controller/controller_client.go
+++ b/pkg/client/controller/controller_client.go
@@ -115,7 +115,7 @@ func (c *Client) CreateIfNotExistsNamespace() error {
 		if err != nil {
 			return err
 		}
-		if errorResponse.Error.Message != "the entry already existed" {
+		if errorResponse.Error.Message != "the entry already existed" && errorResponse.Error.Message != "already exists" {
 			return errors.New(errorResponse.Error.Message)
 		} else {
 			return nil

--- a/pkg/controllers/standard/kvrocks.go
+++ b/pkg/controllers/standard/kvrocks.go
@@ -64,14 +64,19 @@ func (h *KVRocksStandardHandler) ensureKVRocksReplication() error {
 		return h.k8s.UpdateKVRocks(h.instance)
 	} else {
 		for _, node := range h.stsNodes {
+			// Force the first node to be the master.
+			// This logic is consistent with the creation process,
+			// so even if a new node is initially set as the master,
+			// it will still be forced to become a slave below.
 			if node.Role == kvrocks.RoleMaster {
 				if masterIP == "" {
 					masterIP = node.IP
-				} else if masterIP != node.IP {
-					err := errors.New("more than one master exist")
-					h.log.Error(err, "ensure redis replication failed", "master1", masterIP, "master2", node.IP)
-					return err
 				}
+				//else if masterIP != node.IP {
+				//	err := errors.New("more than one master exist")
+				//	h.log.Error(err, "ensure redis replication failed", "master1", masterIP, "master2", node.IP)
+				//	return err
+				//}
 			}
 		}
 		if masterIP == "" {

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -100,7 +100,6 @@ func NewKVRocksConfigMap(instance *kvrocksv1alpha1.KVRocks) *corev1.ConfigMap {
 	} else {
 		delete(instance.Spec.KVRocksConfig, "cluster-enabled")
 	}
-
 	if instance.Spec.Type == kvrocksv1alpha1.StandardType {
 		delete(instance.Spec.KVRocksConfig, "slaveof")
 	}

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -94,12 +94,21 @@ func NewKVRocksConfigMap(instance *kvrocksv1alpha1.KVRocks) *corev1.ConfigMap {
 	buffer.WriteString(fmt.Sprintf("masterauth %s\n", instance.Spec.Password))
 	buffer.WriteString(fmt.Sprintf("requirepass %s\n", instance.Spec.Password))
 	buffer.WriteString("dir /var/lib/kvrocks\n")
+
 	if instance.Spec.Type == kvrocksv1alpha1.ClusterType {
 		buffer.WriteString("cluster-enabled yes\n")
+	} else {
+		if _, ok := instance.Spec.KVRocksConfig["cluster-enabled"]; ok {
+			delete(instance.Spec.KVRocksConfig, "cluster-enabled")
+		}
 	}
+
 	if instance.Spec.Type == kvrocksv1alpha1.StandardType {
-		buffer.WriteString("slaveof 127.0.0.1 6379\n")
+		if _, ok := instance.Spec.KVRocksConfig["slaveof"]; ok {
+			delete(instance.Spec.KVRocksConfig, "slaveof")
+		}
 	}
+
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,

--- a/pkg/resources/configmap.go
+++ b/pkg/resources/configmap.go
@@ -98,15 +98,11 @@ func NewKVRocksConfigMap(instance *kvrocksv1alpha1.KVRocks) *corev1.ConfigMap {
 	if instance.Spec.Type == kvrocksv1alpha1.ClusterType {
 		buffer.WriteString("cluster-enabled yes\n")
 	} else {
-		if _, ok := instance.Spec.KVRocksConfig["cluster-enabled"]; ok {
-			delete(instance.Spec.KVRocksConfig, "cluster-enabled")
-		}
+		delete(instance.Spec.KVRocksConfig, "cluster-enabled")
 	}
 
 	if instance.Spec.Type == kvrocksv1alpha1.StandardType {
-		if _, ok := instance.Spec.KVRocksConfig["slaveof"]; ok {
-			delete(instance.Spec.KVRocksConfig, "slaveof")
-		}
+		delete(instance.Spec.KVRocksConfig, "slaveof")
 	}
 
 	return &corev1.ConfigMap{

--- a/pkg/resources/container.go
+++ b/pkg/resources/container.go
@@ -20,6 +20,21 @@ func NewSentinelContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
 	return container
 }
 
+func NewInitContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
+	return &corev1.Container{
+		Name:            "init-chmod",
+		Image:           "harbor.xaminim.com/minimax-pub/busybox:latest",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"/bin/sh", "-c", " mkdir -p /var/lib/kvrocks && chmod -R 777 /var/lib/kvrocks"},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "data",
+				MountPath: "/var/lib/kvrocks",
+			},
+		},
+	}
+}
+
 func NewInstanceContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
 	container := newKVRocksContainer(instance)
 	container.Command = []string{"sh", "/var/lib/kvrocks/conf/start.sh"}
@@ -35,7 +50,7 @@ func NewExporterContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
 		Name:  "kvrocks-exporter",
 		Image: "hulkdev/kvrocks-exporter:latest",
 		Args: []string{
-			fmt.Sprintf("--kvrocks.addr=http://localhost:%s", strconv.Itoa(kvrocks.KVRocksPort)),
+			fmt.Sprintf("--kvrocks.addr=kvrocks://localhost:%s", strconv.Itoa(kvrocks.KVRocksPort)),
 			fmt.Sprintf("--kvrocks.password=%s", instance.Spec.Password),
 		},
 		Ports: []corev1.ContainerPort{

--- a/pkg/resources/container.go
+++ b/pkg/resources/container.go
@@ -23,7 +23,7 @@ func NewSentinelContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
 func NewInitContainer(instance *kvrocksv1alpha1.KVRocks) *corev1.Container {
 	return &corev1.Container{
 		Name:            "init-chmod",
-		Image:           "harbor.xaminim.com/minimax-pub/busybox:latest",
+		Image:           "busybox:latest",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c", " mkdir -p /var/lib/kvrocks && chmod -R 777 /var/lib/kvrocks"},
 		VolumeMounts: []corev1.VolumeMount{

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -143,18 +143,21 @@ func getPersistentClaim(instance *kvrocksv1alpha1.KVRocks, labels map[string]str
 
 func NewSentinelStatefulSet(instance *kvrocksv1alpha1.KVRocks) *kruise.StatefulSet {
 	sts := NewStatefulSet(instance, GetStatefulSetName(instance.Name))
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, *NewInitContainer(instance))
 	sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *NewSentinelContainer(instance))
 	return sts
 }
 
 func NewReplicationStatefulSet(instance *kvrocksv1alpha1.KVRocks) *kruise.StatefulSet {
 	sts := NewStatefulSet(instance, GetStatefulSetName(instance.Name))
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, *NewInitContainer(instance))
 	sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *NewInstanceContainer(instance), *NewExporterContainer(instance))
 	return sts
 }
 
 func NewClusterStatefulSet(instance *kvrocksv1alpha1.KVRocks, index int) *kruise.StatefulSet {
 	sts := NewStatefulSet(instance, GetStatefulSetName(instance.Name, index))
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, *NewInitContainer(instance))
 	sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, *NewInstanceContainer(instance), *NewExporterContainer(instance))
 	return sts
 }


### PR DESCRIPTION
Description:
This PR improves the error handling logic in the CreateIfNotExistsNamespace function. Specifically:  
It ensures that the error message check for existing entries is more robust and consistent.
Refactors the condition to handle both "the entry already existed" and "already exists" messages.
<hr></hr>
Changes:
Updated the conditional logic in CreateIfNotExistsNamespace to handle specific error messages more effectively.
<hr></hr>