### PR TITLE
Change kubeRBACProxyImage to use bitnami legacy container

### DIFF
--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -6,7 +6,7 @@ managerNamespace:
 imagePullPolicy: Always
 imagePullSecrets:
 
-kubeRBACProxyImage: bitnami/kube-rbac-proxy:0.14.0
+kubeRBACProxyImage: bitnamilegacy/kube-rbac-proxy:0.14.0
 
 resources:
   requests:


### PR DESCRIPTION
fix: switch from bitnami/kube-rbac-proxy:0.14.0 to bitnamilegacy/kube-rbac-proxy:0.14.0

The bitnami/kube-rbac-proxy image was deprecated and removed from Docker Hub, causing image pull errors.
According to [bitnami/charts#35164](https://github.com/bitnami/charts/issues/35164) , the legacy images are now hosted under the bitnamilegacy namespace. This change updates the image reference to use the legacy registry to restore compatibility and ensure successful deployments.